### PR TITLE
step 6 changes

### DIFF
--- a/mdm_artifacts.tf
+++ b/mdm_artifacts.tf
@@ -153,3 +153,16 @@ resource "zentral_mdm_profile" "system-logging-1" {
   macos       = true
   version     = 1
 }
+resource "zentral_mdm_artifact" "mscp-firewall" {
+  name      = "mSCP - firewall"
+  type      = "Profile"
+  channel   = "Device"
+  platforms = ["macOS"]
+}
+
+resource "zentral_mdm_profile" "mscp-firewall-1" {
+  artifact_id = zentral_mdm_artifact.mscp-firewall.id
+  source      = filebase64("${path.module}/mobileconfigs/com.apple.security.firewall.mobileconfig")
+  macos       = true
+  version     = 1
+}

--- a/mdm_default_blueprint.tf
+++ b/mdm_default_blueprint.tf
@@ -68,3 +68,8 @@ resource "zentral_mdm_blueprint_artifact" "system-logging" {
   artifact_id  = zentral_mdm_artifact.system-logging.id
   macos        = true
 }
+resource "zentral_mdm_blueprint_artifact" "mscp-firewall" {
+  blueprint_id = zentral_mdm_blueprint.default.id
+  artifact_id  = zentral_mdm_artifact.mscp-firewall.id
+  macos        = true
+}


### PR DESCRIPTION
We now need to create a new zentral_mdm_artifact resource, link it to the MDM blueprint to put it in scope, and add a zentral_mdm_profile connected to it to load the mobileconfig.

Now that we have the artifact, we need to link it to a blueprint. In the mdm_default_blueprint.tf file,